### PR TITLE
[docker] pull hpacml from zanef2 instead from library repo

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -40,7 +40,7 @@ docker run \
   -v ./benchmarks:/srgt/benchmarks \
   -v ./benchmarks/input_data:/srgt/input_data \
   --rm --gpus all \
-  -it library/hpacml
+  -it zanef2/hpacml
 EOL
 else
     if [ "$build_type" == "download" ]; then


### PR DESCRIPTION
library is the default (implied) namespace for curated packages. hpacml is not available in library, so we need to pull from the author's repo zanef2